### PR TITLE
Respect camera setting in URP

### DIFF
--- a/Source/Renderer/RenderImGui.cs
+++ b/Source/Renderer/RenderImGui.cs
@@ -1,6 +1,7 @@
 ﻿using UnityEngine.Rendering;
 #if HAS_URP
 using UnityEngine.Rendering.Universal;
+using UnityEngine;
 #endif
 
 namespace UImGui.Renderer
@@ -18,6 +19,8 @@ namespace UImGui.Renderer
 			}
 		}
 
+		[HideInInspector]
+		public Camera Camera;
 		public CommandBuffer CommandBuffer;
 		public RenderPassEvent RenderPassEvent = RenderPassEvent.AfterRenderingPostProcessing;
 
@@ -35,6 +38,7 @@ namespace UImGui.Renderer
 		public override void AddRenderPasses(ScriptableRenderer renderer, ref RenderingData renderingData)
 		{
 			if (CommandBuffer == null) return;
+			if (Camera != renderingData.cameraData.camera) return;
 
 			_commandBufferPass.renderPassEvent = RenderPassEvent;
 			_commandBufferPass.commandBuffer = CommandBuffer;

--- a/Source/UImGui.cs
+++ b/Source/UImGui.cs
@@ -130,6 +130,7 @@ namespace UImGui
 
 			if (RenderUtility.IsUsingURP())
 			{
+				_renderFeature.Camera = _camera;
 				_renderFeature.CommandBuffer = _renderCommandBuffer;
 			}
 			else if (!RenderUtility.IsUsingHDRP())
@@ -184,6 +185,7 @@ namespace UImGui
 			{
 				if (_renderFeature != null)
 				{
+					_renderFeature.Camera = null;
 					_renderFeature.CommandBuffer = null;
 				}
 			}


### PR DESCRIPTION
- URP path now only adds its render pass when rendering for the camera specified in UImGui.cs
- Previously all cameras in a camera stack would render the IMGUI pass