### PR TITLE
Fixes/improvement hdrp

### DIFF
--- a/Source/Renderer/RenderImGuiHDPass.cs
+++ b/Source/Renderer/RenderImGuiHDPass.cs
@@ -1,4 +1,4 @@
-﻿#if HAS_HDRP
+#if HAS_HDRP
 using UnityEngine.Rendering;
 using UnityEngine.Rendering.HighDefinition;
 
@@ -26,6 +26,8 @@ namespace UImGui.Renderer
 				cb.Clear();
 			}
 		}
+
+        protected override bool executeInSceneView => false;
 
 		protected override void Cleanup() { }
 	}

--- a/Source/Renderer/RenderImGuiHDPass.cs
+++ b/Source/Renderer/RenderImGuiHDPass.cs
@@ -17,16 +17,16 @@ namespace UImGui.Renderer
 		protected override void Execute(CustomPassContext context)
 		{
             if (!Application.isPlaying) return;
+            var renderContext = context.renderContext;
+            
 			for (int uindex = 0; uindex < _uimguis.Length; uindex++)
 			{
 				UImGui uimgui = _uimguis[uindex];
-				CommandBuffer cb = uimgui.CommandBuffer;
 
-				if (cb == null) continue;
-
-				context.renderContext.ExecuteCommandBuffer(cb);
-				cb.Clear();
+                uimgui.DoUpdate(context.cmd);
+                renderContext.ExecuteCommandBuffer(context.cmd);
 			}
+            renderContext.Submit();
 		}
 
         protected override bool executeInSceneView => false;

--- a/Source/Renderer/RenderImGuiHDPass.cs
+++ b/Source/Renderer/RenderImGuiHDPass.cs
@@ -16,6 +16,7 @@ namespace UImGui.Renderer
 
 		protected override void Execute(CustomPassContext context)
 		{
+            if (!Application.isPlaying) return;
 			for (int uindex = 0; uindex < _uimguis.Length; uindex++)
 			{
 				UImGui uimgui = _uimguis[uindex];

--- a/Source/Renderer/RenderImGuiHDPass.cs
+++ b/Source/Renderer/RenderImGuiHDPass.cs
@@ -11,25 +11,25 @@ namespace UImGui.Renderer
 
 		protected override void Setup(ScriptableRenderContext renderContext, CommandBuffer cmd)
 		{
-            _uimguis = Object.FindObjectsByType<UImGui>(FindObjectsSortMode.None);
+			_uimguis = Object.FindObjectsByType<UImGui>(FindObjectsSortMode.None);
 		}
 
 		protected override void Execute(CustomPassContext context)
 		{
-            if (!Application.isPlaying) return;
-            var renderContext = context.renderContext;
-            
+			if (!Application.isPlaying) return;
+			var renderContext = context.renderContext;
+			
 			for (int uindex = 0; uindex < _uimguis.Length; uindex++)
 			{
 				UImGui uimgui = _uimguis[uindex];
 
-                uimgui.DoUpdate(context.cmd);
-                renderContext.ExecuteCommandBuffer(context.cmd);
+				uimgui.DoUpdate(context.cmd);
+				renderContext.ExecuteCommandBuffer(context.cmd);
 			}
-            renderContext.Submit();
+			renderContext.Submit();
 		}
 
-        protected override bool executeInSceneView => false;
+		protected override bool executeInSceneView => false;
 
 		protected override void Cleanup() { }
 	}

--- a/Source/Renderer/RenderImGuiHDPass.cs
+++ b/Source/Renderer/RenderImGuiHDPass.cs
@@ -1,4 +1,5 @@
 #if HAS_HDRP
+using UnityEngine;
 using UnityEngine.Rendering;
 using UnityEngine.Rendering.HighDefinition;
 
@@ -10,7 +11,7 @@ namespace UImGui.Renderer
 
 		protected override void Setup(ScriptableRenderContext renderContext, CommandBuffer cmd)
 		{
-			_uimguis = UnityEngine.Object.FindObjectsOfType<UImGui>();
+            _uimguis = Object.FindObjectsByType<UImGui>(FindObjectsSortMode.None);
 		}
 
 		protected override void Execute(CustomPassContext context)

--- a/Source/UImGui.cs
+++ b/Source/UImGui.cs
@@ -216,7 +216,7 @@ namespace UImGui
 					_renderFeature.CommandBuffer = null;
 				}
 			}
-			else
+            else if(!RenderUtility.IsUsingHDRP())
 			{
 				if (_camera != null)
 				{
@@ -239,6 +239,13 @@ namespace UImGui
 		}
 
 		private void Update()
+		{
+            if (RenderUtility.IsUsingHDRP())
+                return; // skip update call in hdrp
+            DoUpdate(this.CommandBuffer);
+        }
+
+        internal void DoUpdate(CommandBuffer buffer)
 		{
 			UImGuiUtility.SetCurrentContext(_context);
 			ImGuiIOPtr io = ImGui.GetIO();
@@ -270,7 +277,7 @@ namespace UImGui
 
 			Constants.DrawListMarker.Begin(this);
 			_renderCommandBuffer.Clear();
-			_renderer.RenderDrawLists(_renderCommandBuffer, ImGui.GetDrawData());
+			_renderer.RenderDrawLists(buffer, ImGui.GetDrawData());
 			Constants.DrawListMarker.End();
 
 			if (_isChangingCamera)

--- a/Source/UImGui.cs
+++ b/Source/UImGui.cs
@@ -216,7 +216,7 @@ namespace UImGui
 					_renderFeature.CommandBuffer = null;
 				}
 			}
-            else if(!RenderUtility.IsUsingHDRP())
+			else if(!RenderUtility.IsUsingHDRP())
 			{
 				if (_camera != null)
 				{
@@ -240,12 +240,12 @@ namespace UImGui
 
 		private void Update()
 		{
-            if (RenderUtility.IsUsingHDRP())
-                return; // skip update call in hdrp
-            DoUpdate(this.CommandBuffer);
-        }
+			if (RenderUtility.IsUsingHDRP())
+				return; // skip update call in hdrp
+			DoUpdate(this.CommandBuffer);
+		}
 
-        internal void DoUpdate(CommandBuffer buffer)
+		internal void DoUpdate(CommandBuffer buffer)
 		{
 			UImGuiUtility.SetCurrentContext(_context);
 			ImGuiIOPtr io = ImGui.GetIO();


### PR DESCRIPTION
1. Fixed flickering in 2023 HDRP (remove duplicate call commandBuffer.Clear())
2. Fixed not render when gizmos disabled
3. Fixed render in scene view
4. Fixed mixed command buffer (using command buffer from custom pass)


Potential fixes for: #38, #31
Fixes for: #35

Tested on: 
- 2021.3.31 URP, Builtin, HDRP
- 2023.2.0 HDRP


Proof videos:

Before fixes:


https://github.com/psydack/uimgui/assets/13326808/5114293b-b63f-4d3b-8823-1142474f3488



After fixes:


https://github.com/psydack/uimgui/assets/13326808/7c900691-7331-4a4b-ae4b-24eaeb78ce91

