### PR TITLE
[HDRP] fixes RenderGraph error and gizmos draw problem

### DIFF
--- a/Source/Renderer/RenderImGuiHDPass.cs
+++ b/Source/Renderer/RenderImGuiHDPass.cs
@@ -25,6 +25,10 @@ namespace UImGui.Renderer
 				if (!uimgui || !uimgui.enabled) continue;
 
 				uimgui.DoUpdate(context.cmd);
+
+				#if UNITY_EDITOR
+				context.renderContext.DrawGizmos(context.hdCamera.camera, GizmoSubset.PostImageEffects);
+				#endif
 			}
 		}
 

--- a/Source/Renderer/RenderImGuiHDPass.cs
+++ b/Source/Renderer/RenderImGuiHDPass.cs
@@ -22,6 +22,8 @@ namespace UImGui.Renderer
 			{
 				UImGui uimgui = _uimguis[uindex];
 
+				if (!uimgui || !uimgui.enabled) continue;
+
 				uimgui.DoUpdate(context.cmd);
 			}
 		}

--- a/Source/Renderer/RenderImGuiHDPass.cs
+++ b/Source/Renderer/RenderImGuiHDPass.cs
@@ -17,16 +17,13 @@ namespace UImGui.Renderer
 		protected override void Execute(CustomPassContext context)
 		{
 			if (!Application.isPlaying) return;
-			var renderContext = context.renderContext;
 			
 			for (int uindex = 0; uindex < _uimguis.Length; uindex++)
 			{
 				UImGui uimgui = _uimguis[uindex];
 
 				uimgui.DoUpdate(context.cmd);
-				renderContext.ExecuteCommandBuffer(context.cmd);
 			}
-			renderContext.Submit();
 		}
 
 		protected override bool executeInSceneView => false;


### PR DESCRIPTION
- Remove useless ExecuteCommandBuffer (causing duplicate execution of buffer commands) and & Submit (causing RenderGraph Error exception when other modifications of the main command buffer)
- Handled destroyed\unactive uimgui component (causing RenderGraph Error exception)
- Fix extended gizmos render after buffer modification

Fixes: #31 

Tested on: 2021.3, 2023.2


Before gizmos fix:

https://github.com/psydack/uimgui/assets/13326808/46375763-54a7-4e8b-b471-8856f4a79231

After gizmos fix:

https://github.com/psydack/uimgui/assets/13326808/c0f2f40c-675c-4967-9aed-a5baf64ad4cc


