### PR TITLE
Remove unnecessary GC memory allocations in InputManagerPlatform

### DIFF
--- a/Source/Platform/InputManagerPlatform.cs
+++ b/Source/Platform/InputManagerPlatform.cs
@@ -19,6 +19,7 @@ namespace UImGui.Platform
 	internal sealed class InputManagerPlatform : PlatformBase
 	{
 		private readonly Event _textInputEvent = new Event();
+		private readonly KeyCode[] _keyCodes = (KeyCode[])System.Enum.GetValues(typeof(KeyCode));
 
 		public InputManagerPlatform(CursorShapesAsset cursorShapes, IniSettingsAsset iniSettings) :
 			base(cursorShapes, iniSettings)
@@ -43,7 +44,7 @@ namespace UImGui.Platform
 		private void UpdateKeyboard(ImGuiIOPtr io)
 		{
 			// BUG: mod key make everything slow. Go to line
-			foreach (KeyCode keyCode in System.Enum.GetValues(typeof(KeyCode)))
+			foreach (KeyCode keyCode in _keyCodes)
 			{
 				if (TryMapKeys(keyCode, out ImGuiKey imguikey))
 				{


### PR DESCRIPTION
The use of System.Enum.GetValues(typeof(KeyCode)) allocates 7.8 KiB memory every time it's run (every frame). This isn't ideal in projects that are trying to avoid GC spikes. However, it can be easily fixed by caching the keycodes array.