### PR TITLE
fix: HDRP namespace not being used when URP exists

### DIFF
--- a/Source/Utils/RenderUtility.cs
+++ b/Source/Utils/RenderUtility.cs
@@ -5,7 +5,8 @@ using UnityEngine.Assertions;
 using UnityEngine.Rendering;
 #if HAS_URP
 using UnityEngine.Rendering.Universal;
-#elif HAS_HDRP
+#endif
+#if HAS_HDRP
 using UnityEngine.Rendering.HighDefinition;
 #endif
 


### PR DESCRIPTION
When both URP and HDRP are installed, compliation would fail.