### PR TITLE
Fix System.Runtime.CompilerServices.Unsafe.dll import for Apple Silicon

### DIFF
--- a/Plugins/System.Runtime.CompilerServices.Unsafe.dll.meta
+++ b/Plugins/System.Runtime.CompilerServices.Unsafe.dll.meta
@@ -32,7 +32,7 @@ PluginImporter:
     second:
       enabled: 1
       settings:
-        CPU: x86_64
+        CPU: AnyCPU
         DefaultValueInitialized: true
         OS: AnyOS
   - first:
@@ -46,7 +46,7 @@ PluginImporter:
     second:
       enabled: 1
       settings:
-        CPU: None
+        CPU: AnyCPU
   - first:
       Standalone: Win
     second:


### PR DESCRIPTION
Fixes an issue for Apple Silicon machines