### PR TITLE
Fix ModKeys mapping allowing for keyboard shortcuts

### DIFF
--- a/Source/Platform/InputManagerPlatform.cs
+++ b/Source/Platform/InputManagerPlatform.cs
@@ -52,6 +52,12 @@ namespace UImGui.Platform
 				}
 			}
 
+      			// Handle mod keys separately as 2 buttons map to 1 key
+			io.AddKeyEvent(ImGuiKey.ModShift, Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift));
+			io.AddKeyEvent(ImGuiKey.ModCtrl, Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl));
+			io.AddKeyEvent(ImGuiKey.ModAlt, Input.GetKey(KeyCode.LeftAlt) || Input.GetKey(KeyCode.RightAlt));
+			io.AddKeyEvent(ImGuiKey.ModSuper, Input.GetKey(KeyCode.LeftWindows) || Input.GetKey(KeyCode.RightWindows));
+
 			// Text input.
 			while (Event.PopEvent(_textInputEvent))
 			{
@@ -87,11 +93,19 @@ namespace UImGui.Platform
 				>= KeyCode.Keypad0 and <= KeyCode.Keypad9 => KeyToImGuiKeyShortcut(key, KeyCode.Keypad0, ImGuiKey.Keypad0),
 				>= KeyCode.A and <= KeyCode.Z => KeyToImGuiKeyShortcut(key, KeyCode.A, ImGuiKey.A),
 				>= KeyCode.Alpha0 and <= KeyCode.Alpha9 => KeyToImGuiKeyShortcut(key, KeyCode.Alpha0, ImGuiKey._0),
-				// BUG: mod keys make everything slow. 
-				// KeyCode.LeftShift or KeyCode.RightShift => ImGuiKey.ModShift,
-				// KeyCode.LeftControl or KeyCode.RightControl => ImGuiKey.ModCtrl,
-				// KeyCode.LeftAlt or KeyCode.RightAlt => ImGuiKey.ModAlt,
-				// KeyCode.LeftWindows or KeyCode.RightWindows => ImGuiKey.ModSuper,
+				KeyCode.LeftControl => ImGuiKey.LeftCtrl,
+				KeyCode.RightControl => ImGuiKey.RightCtrl,
+				KeyCode.LeftShift => ImGuiKey.LeftShift,
+				KeyCode.RightShift => ImGuiKey.RightShift,
+				KeyCode.LeftAlt => ImGuiKey.LeftAlt,
+				KeyCode.RightAlt => ImGuiKey.RightAlt,
+#if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX || UNITY_IOS
+				KeyCode.LeftCommand => ImGuiKey.LeftSuper,
+				KeyCode.RightCommand => ImGuiKey.RightSuper,
+#else
+				KeyCode.LeftWindows => ImGuiKey.LeftSuper,
+				KeyCode.RightWindows => ImGuiKey.RightSuper,
+#endif
 				KeyCode.Menu => ImGuiKey.Menu,
 				KeyCode.UpArrow => ImGuiKey.UpArrow,
 				KeyCode.DownArrow => ImGuiKey.DownArrow,

--- a/Source/Platform/InputManagerPlatform.cs
+++ b/Source/Platform/InputManagerPlatform.cs
@@ -52,11 +52,15 @@ namespace UImGui.Platform
 				}
 			}
 
-      			// Handle mod keys separately as 2 buttons map to 1 key
+      		// Handle mod keys separately as 2 buttons map to 1 key
 			io.AddKeyEvent(ImGuiKey.ModShift, Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift));
 			io.AddKeyEvent(ImGuiKey.ModCtrl, Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl));
 			io.AddKeyEvent(ImGuiKey.ModAlt, Input.GetKey(KeyCode.LeftAlt) || Input.GetKey(KeyCode.RightAlt));
+#if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX || UNITY_IOS
+			io.AddKeyEvent(ImGuiKey.ModSuper, Input.GetKey(KeyCode.LeftCommand) || Input.GetKey(KeyCode.RightCommand));
+#else
 			io.AddKeyEvent(ImGuiKey.ModSuper, Input.GetKey(KeyCode.LeftWindows) || Input.GetKey(KeyCode.RightWindows));
+#endif
 
 			// Text input.
 			while (Event.PopEvent(_textInputEvent))


### PR DESCRIPTION
# Issue
Current commented out implementation maps 2 keys to the same modifier key and call it separately.
Input state will flip flop between pressed and released when only 1 modifier key is pressed, resulting in UI slowdown due to repeated input event handling.

# Fix
Use a single `io.AddKeyEvent()` call to activate modifier key when either modifier key is pressed.
Also passthrough the individual modifier keys itself so input handling can be done on the imgui layer for those specific keys.
Additionally map the OSX command key to super.

Resolves #78 and #75

# Workaround
If you are here due to copy paste or any modifier key shortcut not working and the fix is not merged, place the following code into any `Update()` function.
```csharp
void Update()
{
    var io = ImGui.GetIO();
    
    io.AddKeyEvent(ImGuiKey.LeftShift, Input.GetKey(KeyCode.LeftShift));
    io.AddKeyEvent(ImGuiKey.RightShift, Input.GetKey(KeyCode.RightShift));
    io.AddKeyEvent(ImGuiKey.ModShift, Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift));
    
    io.AddKeyEvent(ImGuiKey.LeftCtrl, Input.GetKey(KeyCode.LeftControl));
    io.AddKeyEvent(ImGuiKey.RightCtrl, Input.GetKey(KeyCode.RightControl));
    io.AddKeyEvent(ImGuiKey.ModCtrl, Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl));
    
    io.AddKeyEvent(ImGuiKey.LeftAlt, Input.GetKey(KeyCode.LeftAlt));
    io.AddKeyEvent(ImGuiKey.RightAlt, Input.GetKey(KeyCode.RightAlt));
    io.AddKeyEvent(ImGuiKey.ModAlt, Input.GetKey(KeyCode.LeftAlt) || Input.GetKey(KeyCode.RightAlt));
    
#if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX || UNITY_IOS
    io.AddKeyEvent(ImGuiKey.LeftSuper, Input.GetKey(KeyCode.LeftCommand));
    io.AddKeyEvent(ImGuiKey.RightSuper, Input.GetKey(KeyCode.RightCommand));
    io.AddKeyEvent(ImGuiKey.ModSuper, Input.GetKey(KeyCode.LeftCommand) || Input.GetKey(KeyCode.RightCommand));
#else
    io.AddKeyEvent(ImGuiKey.LeftSuper, Input.GetKey(KeyCode.LeftWindows));
    io.AddKeyEvent(ImGuiKey.RightSuper, Input.GetKey(KeyCode.RightWindows));
    io.AddKeyEvent(ImGuiKey.ModSuper, Input.GetKey(KeyCode.LeftWindows) || Input.GetKey(KeyCode.RightWindows));
#endif
}
```

