### PR TITLE
fix: revert Apple silicon regression

### DIFF
--- a/Plugins/imgui/ImGui.NET.dll.meta
+++ b/Plugins/imgui/ImGui.NET.dll.meta
@@ -31,7 +31,7 @@ PluginImporter:
     second:
       enabled: 1
       settings:
-        CPU: x86_64
+        CPU: AnyCPU
         DefaultValueInitialized: true
         OS: AnyOS
   - first:


### PR DESCRIPTION
Recently updated from v5 to latest. There seems to be a regression on (only) Apple silicon.

Didn't observe any side effects with the provided fix on Linux (editor/build) or Windows (only tested build).